### PR TITLE
Fix error `desktopButton` does not exists (Fixes #1)

### DIFF
--- a/scripts/areas.js
+++ b/scripts/areas.js
@@ -141,6 +141,8 @@ ui.addArea("menu", {
 
 	post() {},
 
+	desktopButton(parent) {},
+
 	mobileButton(parent) {
 		const style = new TextButton.TextButtonStyle(
 			Tex.buttonEdge4,


### PR DESCRIPTION
I just created an empty function so it doesn't crash when it calls `this.desktopButton` ([areas.js:138](https://github.com/DeltaNedas/ui-lib/blob/a5667870493c03512b8707e8aa41c50a6e94d708/scripts/areas.js#L138)).